### PR TITLE
fix(client): replace CRA default metadata with proper MYNA Open Graph + title (#20)

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -18,8 +18,20 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Mapping Your Neighbourhood Avifauna (MYNA): explore bird diversity and generate reports for your area."
     />
+    <!-- Open Graph / Facebook / Discord / WhatsApp -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Mapping Your Neighbourhood Avifauna (MYNA)" />
+    <meta property="og:description" content="Explore bird diversity and generate reports for your neighbourhood." />
+    <meta property="og:image" content="%PUBLIC_URL%/nfcbird.png" />
+    <meta property="og:url" content="https://myna.stateofindiasbirds.in/" />
+    <meta property="og:site_name" content="MYNA" />
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Mapping Your Neighbourhood Avifauna (MYNA)" />
+    <meta name="twitter:description" content="Explore bird diversity and generate reports for your neighbourhood." />
+    <meta name="twitter:image" content="%PUBLIC_URL%/nfcbird.png" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/nfcbird.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -45,7 +57,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
       
-    <title>MYNA</title>
+    <title>Mapping Your Neighbourhood Avifauna (MYNA)</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Fixes #20. `client/public/index.html` still carried Create React App's defaults, `<title>MYNA</title>` and `<meta name="description" content="Web site created using create-react-app">`, so any Discord/WhatsApp/Twitter share preview rendered the generic CRA blurb with no thumbnail.

## Change

`client/public/index.html`:

- **Title:** `Mapping Your Neighbourhood Avifauna (MYNA)` (full project name)
- **Description:** `Explore bird diversity and generate reports for your neighbourhood`
- **Open Graph tags** (`og:type`, `og:title`, `og:description`, `og:image`, `og:url`, `og:site_name`) for Discord / WhatsApp / Facebook / Slack
- **Twitter Card tags** (`twitter:card=summary_large_image`, title/description/image) for X

`og:image` and `twitter:image` reuse the existing `%PUBLIC_URL%/nfcbird.png` favicon so no new assets are needed; consider adding a 1200×630 social card later, but the current image at least replaces the no-thumbnail state.

## Test plan

- [x] Manual check via Discord debugger / opengraph.xyz, preview now renders the full title, description, and bird icon
- [x] No script changes; the file is part of the CRA build, `%PUBLIC_URL%` continues to resolve correctly under `npm run build`